### PR TITLE
Fix: JSON-parse-error 발생

### DIFF
--- a/src/main/java/com/greenUs/server/member/dto/request/SignUpRequest.java
+++ b/src/main/java/com/greenUs/server/member/dto/request/SignUpRequest.java
@@ -2,10 +2,12 @@ package com.greenUs.server.member.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class SignUpRequest {
 


### PR DESCRIPTION
## 구현기능

SignUpRequest default-constructor 추가

## 세부 구현기능

SignUpRequest default-constructor 추가

## 관련이슈

## 기타

에러코드
``` 
WARN [,fb582be270c2112a,fb582be270c2112a] 1443 --- [p-nio-80-exec-5] .w.s.m.s.DefaultHan    dlerExceptionResolver : Resolved [org.springframework.http.converter.HttpMessageNotReadableException: JSON parse     error: Cannot construct instance of `com.greenUs.server.member.dto.request.SignUpRequest` (although at least one     Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator); nested exception     is com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `com.greenUs.server.    member.dto.request.SignUpRequest` (although at least one Creator exists): cannot deserialize from Object value (n    o delegate- or property-based Creator)<EOL> at [Source: (org.springframework.util.StreamUtils$NonClosingInputStre    am); line: 1, column: 2]]
```
[해결 참고 블로그](https://moonsiri.tistory.com/104)