### PR TITLE
Fix: 게시글 작성 에러부분 해결

### DIFF
--- a/src/main/java/com/greenUs/server/post/controller/PostController.java
+++ b/src/main/java/com/greenUs/server/post/controller/PostController.java
@@ -10,9 +10,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -101,13 +103,12 @@ public class PostController {
 	@PostMapping
 	public ResponseEntity<Integer> createPost(
 		@Parameter(description = "accessToken 값", in = ParameterIn.HEADER) @AuthenticationPrincipal LoginMember loginMember,
-		@Parameter(description = "게시글 첨부파일 리스트", in = ParameterIn.PATH) @RequestPart(required = false) List<MultipartFile> multipartFiles,
-		@Parameter(description = "게시글 구분(kind), 제목(title), 내용(content), 가격(price)(중고 거래 게시글일 경우), 해시태그(hashtag)", in = ParameterIn.PATH) @RequestPart PostRequest postRequestDto) {
+		@Parameter(description = "필수요소 : 게시글 구분(kind), 제목(title), 내용(content), 가격(price)(중고 거래 게시글일 경우) / 선택요소 : 해시태그(hashtag), 첨부파일(multipartFiles)", in = ParameterIn.PATH) PostRequest postRequestDto) {
 
 		Member member = memberRepository.findById(loginMember.getId()).orElseThrow(NotFoundMemberException::new);
 		postRequestDto.setMember(member);
 
-		Integer kind = postService.createPost(multipartFiles, postRequestDto);
+		Integer kind = postService.createPost(postRequestDto);
 
 		return new ResponseEntity<>(kind, HttpStatus.CREATED);
 	}
@@ -120,14 +121,13 @@ public class PostController {
 	@PutMapping("/{id}")
 	public ResponseEntity<Integer> updatePost(
 		@Parameter(description = "accessToken 값", in = ParameterIn.HEADER) @AuthenticationPrincipal LoginMember loginMember,
-		@Parameter(description = "게시글 첨부파일 리스트", in = ParameterIn.PATH) @RequestPart(required = false) List<MultipartFile> multipartFiles,
 		@Parameter(description = "게시글 번호", in = ParameterIn.PATH) @PathVariable Long id,
-		@Parameter(description = "게시글 구분(kind), 제목(title), 내용(content), 가격(price)(중고 거래 게시글일 경우만), 삭제할 첨부파일 이름 리스트(storedFileNames), 해시태그(hashtags)", in = ParameterIn.PATH) @RequestPart PostRequest postRequestDto) {
+		@Parameter(description = "필수요소 : 게시글 구분(kind), 제목(title), 내용(content), 가격(price)(중고 거래 게시글일 경우) / 선택요소 : 해시태그(hashtag), 첨부파일(multipartFiles)", in = ParameterIn.PATH) PostRequest postRequestDto) {
 
 		Member member = memberRepository.findById(loginMember.getId()).orElseThrow(NotFoundMemberException::new);
 		postRequestDto.setMember(member);
 
-		Integer kind = postService.updatePost(id, multipartFiles, postRequestDto);
+		Integer kind = postService.updatePost(id, postRequestDto);
 		return new ResponseEntity<>(kind, HttpStatus.CREATED);
 	}
 

--- a/src/main/java/com/greenUs/server/post/dto/PostRequest.java
+++ b/src/main/java/com/greenUs/server/post/dto/PostRequest.java
@@ -3,6 +3,8 @@ package com.greenUs.server.post.dto;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.greenUs.server.member.domain.Member;
 import com.greenUs.server.post.domain.Post;
 
@@ -37,11 +39,14 @@ public class PostRequest {
 	@Schema(description = "게시판 파일 첨부 여부(false: 미첨부, true:첨부)", nullable = true)
 	private Boolean fileAttached;
 
-	@Schema(description = "서버에 저장된 파일 이름", example = "[서버에 저장된 파일 이름, 서버에 저장된 파일 이름]", nullable = true)
+	@Schema(description = "삭제할 첨부파일 이름", example = "[삭제할 첨부파일 이름, 삭제할 첨부파일 이름]", nullable = true)
 	private List<String> storedFileNames = new ArrayList<>();
 
 	@Schema(description = "게시판 해시태그", example = "#그리너스#지구", nullable = true)
 	private String hashtag = "";
+
+	@Schema(description = "게시판 첨부파일", example = "[첨부파일, 첨부파일]", nullable = true)
+	private List<MultipartFile> multipartFiles;
 
 	public Post toEntity() {
 		return Post.builder()

--- a/src/main/java/com/greenUs/server/post/service/PostService.java
+++ b/src/main/java/com/greenUs/server/post/service/PostService.java
@@ -68,18 +68,18 @@ public class PostService {
 	}
 
 	@Transactional
-	public Integer createPost(List<MultipartFile> multipartFiles, PostRequest postRequestDto) {
+	public Integer createPost(PostRequest postRequestDto) {
 
-		if (!(multipartFiles == null || multipartFiles.isEmpty()))
+		if (!(postRequestDto.getMultipartFiles() == null || postRequestDto.getMultipartFiles().isEmpty()))
 			postRequestDto.setFileAttached(true);
 		else {
 			postRequestDto.setFileAttached(false);
 		}
-
+		System.out.println("postRequestDto = " + postRequestDto);
 		Post post = postRepository.save(postRequestDto.toEntity());
 
-		if (!(multipartFiles == null || multipartFiles.isEmpty()))
-			attachmentService.createAttachment(post, multipartFiles);
+		if (!(postRequestDto.getMultipartFiles() == null || postRequestDto.getMultipartFiles().isEmpty()))
+			attachmentService.createAttachment(post, postRequestDto.getMultipartFiles());
 
 		if (!postRequestDto.getHashtag().isEmpty())
 			hashtagService.applyHashtag(post, postRequestDto.getHashtag());
@@ -88,7 +88,7 @@ public class PostService {
 	}
 
 	@Transactional
-	public Integer updatePost(Long id, List<MultipartFile> multipartFiles, PostRequest postRequestDto) {
+	public Integer updatePost(Long id, PostRequest postRequestDto) {
 
 		Post post = postRepository.findById(id).orElseThrow(NotFoundPostException::new);
 
@@ -99,8 +99,8 @@ public class PostService {
 		if (!postRequestDto.getStoredFileNames().isEmpty())
 			attachmentService.deleteAttachment(id, postRequestDto.getStoredFileNames());
 
-		if (!(multipartFiles == null || multipartFiles.isEmpty()))
-			attachmentService.createAttachment(post, multipartFiles);
+		if (!(postRequestDto.getMultipartFiles() == null || postRequestDto.getMultipartFiles().isEmpty()))
+			attachmentService.createAttachment(post, postRequestDto.getMultipartFiles());
 
 		List<Attachment> attachments = attachmentService.getAttachmentInfoByPostId(id);
 		if (attachments.size() == 0)

--- a/src/main/java/com/greenUs/server/post/service/PostService.java
+++ b/src/main/java/com/greenUs/server/post/service/PostService.java
@@ -75,7 +75,7 @@ public class PostService {
 		else {
 			postRequestDto.setFileAttached(false);
 		}
-		System.out.println("postRequestDto = " + postRequestDto);
+
 		Post post = postRepository.save(postRequestDto.toEntity());
 
 		if (!(postRequestDto.getMultipartFiles() == null || postRequestDto.getMultipartFiles().isEmpty()))


### PR DESCRIPTION
## 구현기능

1. 게시글 작성 컨트롤러 @RequestPart -> @ModelAttribute
2. 게시글 이미지 형태 MultipartFile을 DTO내 필드로 삽입

## 세부 구현기능

@RequestPart의 정의와 작동원리는 다음과 같습니다.
>@RequestPart
- Content-type이 'multipart/form-data'와 관련된 경우에 사용한다.
- MultipartFile이 포함되는 경우에 MutliPartResolver가 동작하여 역직렬화를 하게 됨.
- MultipartFile이 포함되지 않는 경우(여기서는 게시글 내용 DTO)는 @RequestBody와 같이 HttpMessageConverter가 동작하게 된다.
- 사용 방법: @RequestBody가 필요하지만 Binary Stream이 포함되는 경우(MultipartFile과 같은)에 사용할 수 있다.

★ RequestBody는 HTTP 요청으로 같이 넘어오는 Header의 Content-type을 보고 어떤 Converter를 사용할지 정하기에 Content-type을 반드시 명시해야 한다.

---

프론트 측에서 게시글 작성은 한번의 요청으로 이미지와 게시글 내용에 대한 데이터를 보내기 때문에 Content-type은 multipart/form-data로 전달 될 수 밖에 없다고 하셨고,  스프링에서는 내부적으로 Converter가 Content-type 을 보고 게시글 내용에 대한 DTO도 json형식이 아닌 multipart/form-data으로 판단하였기 때문에 발생한 에러로 보입니다.

포스트맨에서 적상작동한 이유는 다음과 같이 테스트 할때 DTO에 대한 부분은 따로 application/json이라고 명시를 해줬기 때문에 정상작동한 것으로 보입니다.

![image](https://user-images.githubusercontent.com/87755660/225297793-7ca0f99e-604f-43a9-9c9a-0e02b1aa743c.png)

---

그래서 multipartFile을 DTO내에 필드로 넣고, 컨트롤러에 인자에 대한 매핑은 @ModelAttribute를 이용하여 정상작동함을 확인했습니다.

>@ModelAttribute
- Content-type이 multipart/form-data의 형태를 받을때 사용
- HTTP 파라미터를 받는 경우 사용

즉 HTTP body로 오든 파라미터로 오든 다 받을 수 있고 body와 파라미터가 같이 오는 경우에도 값이 바인딩됩니다. @RequestPart와 다른 점은 HttpMessageConverter에 의해 값이 바인딩되는 것이 아닌 적절한 Setter 혹은 Constructor를 통해 값이 주입된다는 점입니다.
**★이런 형태가 가능한 이유는 @ModelAttribute는 필드 내부와 1:1로 값이 Setter나 Constructor를 통해 매핑되기 때문입니다.★**

![image](https://user-images.githubusercontent.com/87755660/225298973-cef5a164-c88c-48a2-9f78-7d1cbc889f4b.png)

**정상 작동 확인**
![image](https://user-images.githubusercontent.com/87755660/225299016-9dc74ca8-7a2d-4533-9a54-15c3ec22b5f4.png)

## 관련이슈

#69 

## 기타

- 배포 후 100% 정상작동 되는지 확인할 예정입니다. 
- 오류 해결하는데 참고한 링크입니다.
[1. @RequestBody, @ModelAttribute, @RequestParam, @RequestPart에 대해 잘 정리된 글](https://middleearth.tistory.com/35)
[2. 파일과 데이터 요청을 하나의 객체로 바인딩 하기에 대한 글](https://galid1.tistory.com/754)