### PR TITLE
Refactor: comment DTO에 parentId 추가

### DIFF
--- a/src/main/java/com/greenUs/server/comment/dto/CommentResponse.java
+++ b/src/main/java/com/greenUs/server/comment/dto/CommentResponse.java
@@ -16,6 +16,9 @@ public class CommentResponse {
 	@Schema(description = "댓글 번호", nullable = false, example = "47")
 	private Long id;
 
+	@Schema(description = "부모 댓글 번호", nullable = false, example = "22")
+	private Long parentId;
+
 	@Schema(description = "댓글 작성자 닉네임", nullable = false)
 	private CommunityMemberResponse commentMember;
 
@@ -24,6 +27,7 @@ public class CommentResponse {
 
 	public CommentResponse(Comment entity) {
 		this.id = entity.getId();
+		this.parentId = entity.getParent() != null ? entity.getParent().getId() : null;
 		this.commentMember = new CommunityMemberResponse(entity);
 		this.content = entity.getContent();
 	}

--- a/src/main/java/com/greenUs/server/comment/exception/NotEqualCommentAndPostComment.java
+++ b/src/main/java/com/greenUs/server/comment/exception/NotEqualCommentAndPostComment.java
@@ -1,0 +1,12 @@
+package com.greenUs.server.comment.exception;
+
+public class NotEqualCommentAndPostComment extends RuntimeException {
+
+	public NotEqualCommentAndPostComment(String message) {
+		super(message);
+	}
+
+	public NotEqualCommentAndPostComment() {
+		this("해당하는 게시글의 댓글 번호가 아닙니다.");
+	}
+}

--- a/src/main/java/com/greenUs/server/comment/repository/CommentRepository.java
+++ b/src/main/java/com/greenUs/server/comment/repository/CommentRepository.java
@@ -1,5 +1,7 @@
 package com.greenUs.server.comment.repository;
 
+import java.util.Optional;
+
 import com.greenUs.server.comment.domain.Comment;
 
 import org.springframework.data.domain.Page;
@@ -16,4 +18,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	// 내가 작성한 댓글 반환
 	Page<Comment> findByMemberId(Long id, PageRequest pageRequest);
+
+	Optional<Comment> findByIdAndPostId(Long Id, Long postId);
 }

--- a/src/main/java/com/greenUs/server/comment/service/CommentService.java
+++ b/src/main/java/com/greenUs/server/comment/service/CommentService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.greenUs.server.comment.domain.Comment;
 import com.greenUs.server.comment.dto.CommentRequest;
 import com.greenUs.server.comment.dto.CommentResponse;
+import com.greenUs.server.comment.exception.NotEqualCommentAndPostComment;
 import com.greenUs.server.comment.exception.NotEqualMemberAndCommentMember;
 import com.greenUs.server.comment.exception.NotFoundCommentException;
 import com.greenUs.server.comment.repository.CommentRepository;
@@ -63,6 +64,9 @@ public class CommentService {
 		Post post = postRepository.findById(commentRequestDto.getPostId())
 			.orElseThrow(NotFoundPostException::new);
 
+		commentRepository.findByIdAndPostId(parentId, commentRequestDto.getPostId())
+			.orElseThrow(NotEqualCommentAndPostComment::new);
+
 		Comment comment = Comment.builder()
 			.member(member)
 			.post(post)
@@ -70,7 +74,7 @@ public class CommentService {
 			.build();
 
 		comment.confirmParent(commentRepository.findById(parentId)
-			.orElseThrow(() -> new NotFoundCommentException()));
+			.orElseThrow(NotFoundCommentException::new));
 
 		commentRepository.save(comment);
 	}

--- a/src/main/java/com/greenUs/server/global/error/ErrorCode.java
+++ b/src/main/java/com/greenUs/server/global/error/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     INVALID_TOKEN(401, "잘못된 토큰입니다."),
     EXPIRED_TOKEN(401, "만료된 토큰입니다."),
     POST_MEMBER_NOT_EQUAL(403, "게시글의 작성자가 아닙니다."),
+    POST_COMMENT_NOT_EQUAL(403,"해당하는 게시글의 댓글 번호가 아닙니다."),
     POST_ATTACHMENT_NOT_EQUAL(403, "게시글의 첨부파일 이름이 아닙니다."),
     COMMENT_MEMBER_NOT_EQUAL(403, "댓글의 작성자가 아닙니다."),
     OBJECT_NOT_FOUND(404,"이미 삭제된 파일로 찾을 수 없습니다."),

--- a/src/main/java/com/greenUs/server/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/greenUs/server/global/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.greenUs.server.attachment.exception.NotEqualAttachmentAndPostAttachme
 import com.greenUs.server.attachment.exception.NotFoundObjectException;
 import com.greenUs.server.auth.exception.EmptyAuthorizationHeaderException;
 import com.greenUs.server.auth.exception.InvalidTokenException;
+import com.greenUs.server.comment.exception.NotEqualCommentAndPostComment;
 import com.greenUs.server.comment.exception.NotEqualMemberAndCommentMember;
 import com.greenUs.server.comment.exception.NotFoundCommentException;
 import com.greenUs.server.infrastructure.oauth.exception.OAuthException;
@@ -69,6 +70,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NotEqualMemberAndCommentMember.class)
     public ResponseEntity<ErrorResponse> handleNotEqualMemberAndCommentMember() {
         ErrorResponse response = new ErrorResponse(ErrorCode.COMMENT_MEMBER_NOT_EQUAL);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(NotEqualCommentAndPostComment.class)
+    public ResponseEntity<ErrorResponse> handleNotEqualCommentAndPostComment() {
+        ErrorResponse response = new ErrorResponse(ErrorCode.POST_COMMENT_NOT_EQUAL);
         return ResponseEntity.badRequest().body(response);
     }
 


### PR DESCRIPTION
## 구현기능

1. comment DTO에 parentId 추가
2. 게시글의 댓글과 다른 댓글 번호가 들어오는 경우 예외처리

## 세부 구현기능

- 댓글과 답글을 구별하기 위해 parentId도 DTO에 반환하도록 하였습니다.
- 게시글의 댓글과 다른 댓글 번호가 들어오는 경우에 대한 예외처리 하였습니다.

## 관련이슈

#79 

## 기타