### PR TITLE
Refactor: 마이페이지 댓글 response 데이터 추가

### DIFF
--- a/src/main/java/com/greenUs/server/member/dto/response/MyPageCommentResponse.java
+++ b/src/main/java/com/greenUs/server/member/dto/response/MyPageCommentResponse.java
@@ -1,4 +1,4 @@
-package com.greenUs.server.post.dto.response;
+package com.greenUs.server.member.dto.response;
 
 import com.greenUs.server.comment.domain.Comment;
 
@@ -19,6 +19,9 @@ public class MyPageCommentResponse {
 	@Schema(description = "게시판 구분(1: 자유게시판, 2: 정보 공유, 3: 중고 거래)", nullable = false, allowableValues = {"1", "2", "3"})
 	private Integer kind;
 
+	@Schema(description = "게시판 제목", nullable = false, example = "게시글 제목 입니다.")
+	private String postTitle;
+
 	@Schema(description = "댓글 내용", nullable = false)
 	private String content;
 
@@ -29,6 +32,7 @@ public class MyPageCommentResponse {
 		this.id = entity.getId();
 		this.postId = entity.getPost().getId();
 		this.kind = entity.getPost().getKind();
+		this.postTitle = entity.getPost().getTitle();
 		this.content = entity.getContent();
 		this.replyCnt = entity.getPost().getComments().size();
 	}

--- a/src/main/java/com/greenUs/server/member/dto/response/MyPageCommunityResponse.java
+++ b/src/main/java/com/greenUs/server/member/dto/response/MyPageCommunityResponse.java
@@ -1,8 +1,5 @@
 package com.greenUs.server.member.dto.response;
 
-import com.greenUs.server.post.dto.response.MyPageCommentResponse;
-import com.greenUs.server.post.dto.response.MyPagePostResponse;
-
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 

--- a/src/main/java/com/greenUs/server/member/dto/response/MyPagePostResponse.java
+++ b/src/main/java/com/greenUs/server/member/dto/response/MyPagePostResponse.java
@@ -1,4 +1,4 @@
-package com.greenUs.server.post.dto.response;
+package com.greenUs.server.member.dto.response;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/greenUs/server/member/service/MemberService.java
+++ b/src/main/java/com/greenUs/server/member/service/MemberService.java
@@ -1,7 +1,6 @@
 package com.greenUs.server.member.service;
 
 import com.greenUs.server.member.dto.response.*;
-import com.greenUs.server.product.domain.ProductLike;
 import com.greenUs.server.product.repository.ProductLikeRepository;
 import com.greenUs.server.product.repository.ProductRepository;
 import org.springframework.data.domain.Page;
@@ -18,8 +17,8 @@ import com.greenUs.server.member.dto.request.MemberRequest;
 import com.greenUs.server.member.dto.request.SignUpRequest;
 import com.greenUs.server.member.exception.NotFoundMemberException;
 import com.greenUs.server.member.repository.MemberRepository;
-import com.greenUs.server.post.dto.response.MyPageCommentResponse;
-import com.greenUs.server.post.dto.response.MyPagePostResponse;
+import com.greenUs.server.member.dto.response.MyPageCommentResponse;
+import com.greenUs.server.member.dto.response.MyPagePostResponse;
 import com.greenUs.server.post.repository.PostRepository;
 import com.greenUs.server.purchase.dto.response.PurchaseResponse;
 import com.greenUs.server.purchase.repository.PurchaseRepository;


### PR DESCRIPTION
## 구현기능

마이페이지 댓글 response 데이터 추가

## 세부 구현기능
![image](https://user-images.githubusercontent.com/87755660/227842760-4f343096-ec27-4f2c-90b0-9b329f0cbbba.png)

마이페이지 댓글 response 게시글 제목 필드(postTitle) 추가

## 관련이슈

#87 

## 기타

마이페이지 게시글, 댓글 response post-dto에서 member-dto로 이동했습니다.