### PR TITLE
Refactor: 이미지 로딩에 대한 CDN 적용

### DIFF
--- a/src/main/java/com/greenUs/server/attachment/service/AttachmentService.java
+++ b/src/main/java/com/greenUs/server/attachment/service/AttachmentService.java
@@ -33,6 +33,8 @@ public class AttachmentService {
 
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
+	@Value("${cloud.aws.cloudfront.domain}")
+	private String cloudfrontDomain;
 	private final AmazonS3 amazonS3;
 	private final AttachmentRepository attachmentRepository;
 	private static final int FREE_INFO_POST_WIDTH = 100;
@@ -124,7 +126,7 @@ public class AttachmentService {
 	}
 
 	private String getAmazonS3Url(String fileName) {
-		return amazonS3.getUrl(bucket, fileName).toString();
+		return cloudfrontDomain + amazonS3.getUrl(bucket, fileName).getPath();
 	}
 
 	private void putAmazonS3Object(String fileName, MultipartFile file, ObjectMetadata objMeta) {


### PR DESCRIPTION
## 구현기능

이미지 로딩에 대한 CDN 적용

## 세부 구현기능

이미지를 호출할때 마다 버킷에 접근하게 되면 시간도 많이 걸리기 때문에 
캐싱 기능을 이용하는 AWS의 CDN을 적용하여 속도를 개선하였습니다.
버킷에 대한 경로 앞에 단순히 CDN 도메인을 입력함으로써 적용시킬 수 있었습니다.

## 관련이슈

#89 

## 기타

학습하고 적용했던 자료 올립니다.
[CDN을 이해하고 적용하기 위해 참고한 블로그](https://velog.io/@doohyunlm/AWS-CloudFront-%EA%B0%9C%EB%85%90)
[CDN을 이해하고 적용하기 위해 참고한 블로그 (2)](https://jjuunn.tistory.com/31)