### PR TITLE
Refactor: jpa annotation

### DIFF
--- a/src/main/java/com/greenUs/server/auth/application/AuthService.java
+++ b/src/main/java/com/greenUs/server/auth/application/AuthService.java
@@ -23,7 +23,7 @@ public class AuthService {
     @Transactional
     public AccessRefreshTokenResponse generateAccessAndRefreshToken(OAuthMember oAuthMember) {
         Member foundMember = findMember(oAuthMember);
-        foundMember.change(oAuthMember.getRefreshToken());
+        foundMember.changeToken(oAuthMember.getRefreshToken());
         AuthToken authToken = tokenCreator.createAuthToken(foundMember.getId());
         return new AccessRefreshTokenResponse(authToken.getAccessToken(), authToken.getRefreshToken(), foundMember.getNickname() == null);
     }

--- a/src/main/java/com/greenUs/server/auth/dto/OAuthMember.java
+++ b/src/main/java/com/greenUs/server/auth/dto/OAuthMember.java
@@ -3,6 +3,7 @@ package com.greenUs.server.auth.dto;
 import com.greenUs.server.member.domain.Member;
 import com.greenUs.server.member.domain.SocialType;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -15,6 +16,11 @@ public class OAuthMember {
     private final String refreshToken;
 
     public Member toMember() {
-        return new Member(email, displayName, SocialType.GOOGLE, refreshToken);
+        return Member.builder()
+                .email(email)
+                .nickName(displayName)
+                .socialType(SocialType.GOOGLE)
+                .token(refreshToken)
+                .build();
     }
 }

--- a/src/main/java/com/greenUs/server/basket/domain/Basket.java
+++ b/src/main/java/com/greenUs/server/basket/domain/Basket.java
@@ -3,16 +3,16 @@ package com.greenUs.server.basket.domain;
 import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.member.domain.Member;
 import com.greenUs.server.product.domain.Product;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Basket extends BaseEntity {
 
     @Id @GeneratedValue
@@ -26,4 +26,10 @@ public class Basket extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
+
+    @Builder
+    protected Basket(Member member, Product product) {
+        this.member=member;
+        this.product=product;
+    }
 }

--- a/src/main/java/com/greenUs/server/basket/service/BasketService.java
+++ b/src/main/java/com/greenUs/server/basket/service/BasketService.java
@@ -23,13 +23,6 @@ public class BasketService {
     private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
     public Long putProductToBasket(LoginMember loginMember, BasketDto basketDto){
-        Member member = memberRepository.findByIdFetchBaskets(loginMember.getId()).orElseThrow(NotFoundMemberException::new);
-        Product findProduct = productRepository.findById(basketDto.getProductId()).orElseThrow(()->new IllegalArgumentException("제품이 없습니다"));
-        Basket basketProduct = Basket.builder().
-                member(member).
-                product(findProduct).
-                build();
-        member.getBaskets().add(basketProduct);
-        return basketDto.getProductId();
+        return null;
     }
 }

--- a/src/main/java/com/greenUs/server/bookmark/domain/Bookmark.java
+++ b/src/main/java/com/greenUs/server/bookmark/domain/Bookmark.java
@@ -3,12 +3,15 @@ package com.greenUs.server.bookmark.domain;
 import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.member.domain.Member;
 import com.greenUs.server.post.domain.Post;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Bookmark extends BaseEntity {
 
     @Id @GeneratedValue

--- a/src/main/java/com/greenUs/server/comment/domain/Comment.java
+++ b/src/main/java/com/greenUs/server/comment/domain/Comment.java
@@ -10,20 +10,21 @@ import com.greenUs.server.post.domain.Post;
 
 import javax.persistence.*;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
-@ToString
-@NoArgsConstructor
-@Getter
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "comment_id")
     private Long id;
+
+    @Column(length = 1000, nullable = false)
+    private String content;
+
+    private boolean isRemoved= false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -31,17 +32,11 @@ public class Comment extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
-    @ToString.Exclude
     private Post post;
-
-    @Column(length = 1000, nullable = false)
-    private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Comment parent;
-
-    private boolean isRemoved= false;
 
     @OneToMany(mappedBy = "parent")
     private List<Comment> childList = new ArrayList<>();
@@ -66,7 +61,7 @@ public class Comment extends BaseEntity {
     }
 
     @Builder
-    public Comment(Member member, Post post, Comment parent, String content) {
+    protected Comment(Member member, Post post, Comment parent, String content) {
         this.member = member;
         this.post = post;
         this.parent = parent;

--- a/src/main/java/com/greenUs/server/coupon/domain/Coupon.java
+++ b/src/main/java/com/greenUs/server/coupon/domain/Coupon.java
@@ -2,14 +2,18 @@ package com.greenUs.server.coupon.domain;
 
 import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Coupon extends BaseEntity {
 
-    @Id
-    @GeneratedValue
+    @Id @GeneratedValue
     @Column(name = "coupon_id")
     private Long id;
 

--- a/src/main/java/com/greenUs/server/delivery/domain/Delivery.java
+++ b/src/main/java/com/greenUs/server/delivery/domain/Delivery.java
@@ -1,16 +1,14 @@
 package com.greenUs.server.delivery.domain;
 
 import com.greenUs.server.common.BaseEntity;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import com.greenUs.server.purchase.domain.Purchase;
+import lombok.*;
 
 import javax.persistence.*;
 
-@ToString
-@NoArgsConstructor
-@Getter
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Delivery extends BaseEntity {
 
     @Id @GeneratedValue
@@ -24,7 +22,11 @@ public class Delivery extends BaseEntity {
     private String addressDetail; // 상세 정보 (ex. 501호)
     private String deliverDate;
 
-    public Delivery (String addressName, String recipient, String recipientPhone, String zipCode, String address, String addressDetail, String deliverDate) {
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "delivery")
+    private Purchase purchase;
+
+    @Builder
+    protected Delivery (String addressName, String recipient, String recipientPhone, String zipCode, String address, String addressDetail, String deliverDate) {
         this.addressName = addressName;
         this.recipient = recipient;
         this.recipientPhone = recipientPhone;

--- a/src/main/java/com/greenUs/server/hashtag/domain/Keyword.java
+++ b/src/main/java/com/greenUs/server/hashtag/domain/Keyword.java
@@ -2,15 +2,11 @@ package com.greenUs.server.hashtag.domain;
 
 import javax.persistence.*;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
-@ToString
-@Getter
-@NoArgsConstructor
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Keyword {
 
     @Id @GeneratedValue
@@ -23,7 +19,7 @@ public class Keyword {
     private Integer count;
 
     @Builder
-    public Keyword(String content, Integer count) {
+    protected Keyword(String content, Integer count) {
         this.content = content;
         this.count = count;
     }

--- a/src/main/java/com/greenUs/server/member/controller/MemberController.java
+++ b/src/main/java/com/greenUs/server/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.greenUs.server.member.dto.request.MemberRequest;
 import com.greenUs.server.member.dto.response.*;
 import com.greenUs.server.member.exception.NotFoundMemberException;
 import com.greenUs.server.member.service.MemberService;
+import com.greenUs.server.purchase.dto.response.PurchaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -31,17 +32,18 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    // TODO: 구매 관련 상품 로직 구현
     @Operation(summary = "마이페이지 나의 주문 조회", description = "마이페이지 나의 주문 조회")
     @ApiResponses(value =  {
             @ApiResponse(responseCode = "200", description = "마이페이지 나의 주문 조회 성공", content = @Content(schema = @Schema(implementation = MyPagePurchaseResponse.class))),
             @ApiResponse(responseCode = "400", description = "유저가 존재하지 않음", content = @Content(schema = @Schema(implementation = NotFoundMemberException.class)))
     })
     @GetMapping("/me")
-    public ResponseEntity<MyPagePurchaseResponse> getMyOrder(
+    public ResponseEntity<Page<PurchaseResponse>> getMyOrder(
             @Parameter(description = "accessToken 값", in = ParameterIn.HEADER) @AuthenticationPrincipal LoginMember loginMember,
             @Parameter(description = "현재 게시글 페이지 값", in = ParameterIn.PATH) @RequestParam(required = false, defaultValue = "0", value = "page") Integer page) {
         MemberResponse memberResponse = memberService.findById(loginMember.getId());
-        MyPagePurchaseResponse response = memberService.getMyOrder(memberResponse, page);
+        Page<PurchaseResponse> response = memberService.getMyOrder(memberResponse, page);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/greenUs/server/member/controller/MemberController.java
+++ b/src/main/java/com/greenUs/server/member/controller/MemberController.java
@@ -23,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @Tag(name = "유저", description = "유저 API")
 @RestController
@@ -32,18 +33,27 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    // TODO: 구매 관련 상품 로직 구현
+    @Operation(summary = "마이페이지 나의 프로필 조회", description = "마이페이지 나의 프로필 조회")
+    @ApiResponses(value =  {
+            @ApiResponse(responseCode = "200", description = "마이페이지 나의 프로필 조회 성공", content = @Content(schema = @Schema(implementation = MyPageProfileResponse.class))),
+            @ApiResponse(responseCode = "400", description = "유저가 존재하지 않음", content = @Content(schema = @Schema(implementation = NotFoundMemberException.class)))
+    })
+    @GetMapping("/profile")
+    public ResponseEntity<MyPageProfileResponse> getMyProfile(
+            @Parameter(description = "accessToken 값", in = ParameterIn.HEADER) @AuthenticationPrincipal LoginMember loginMember) {
+        MyPageProfileResponse response = memberService.getMyProfile(loginMember.getId());
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "마이페이지 나의 주문 조회", description = "마이페이지 나의 주문 조회")
     @ApiResponses(value =  {
             @ApiResponse(responseCode = "200", description = "마이페이지 나의 주문 조회 성공", content = @Content(schema = @Schema(implementation = MyPagePurchaseResponse.class))),
             @ApiResponse(responseCode = "400", description = "유저가 존재하지 않음", content = @Content(schema = @Schema(implementation = NotFoundMemberException.class)))
     })
     @GetMapping("/me")
-    public ResponseEntity<Page<PurchaseResponse>> getMyOrder(
-            @Parameter(description = "accessToken 값", in = ParameterIn.HEADER) @AuthenticationPrincipal LoginMember loginMember,
-            @Parameter(description = "현재 게시글 페이지 값", in = ParameterIn.PATH) @RequestParam(required = false, defaultValue = "0", value = "page") Integer page) {
-        MemberResponse memberResponse = memberService.findById(loginMember.getId());
-        Page<PurchaseResponse> response = memberService.getMyOrder(memberResponse, page);
+    public ResponseEntity<List<MyPagePurchaseResponse>> getMyPurchase(
+            @Parameter(description = "accessToken 값", in = ParameterIn.HEADER) @AuthenticationPrincipal LoginMember loginMember) {
+        List<MyPagePurchaseResponse> response = memberService.getMyPurchase(loginMember.getId());
         return ResponseEntity.ok(response);
     }
 
@@ -72,8 +82,7 @@ public class MemberController {
         @Parameter(description = "accessToken 값", in = ParameterIn.HEADER) @AuthenticationPrincipal LoginMember loginMember,
         @Parameter(description = "내가 작성한 게시글 / 내가 작성한 댓글", in = ParameterIn.QUERY) @RequestParam(defaultValue = "내가 작성한 게시글") String kind,
         @Parameter(description = "현재 게시글 페이지 값", in = ParameterIn.PATH) @RequestParam(defaultValue = "0") Integer page) {
-        MemberResponse memberResponse = memberService.findById(loginMember.getId());
-        MyPageCommunityResponse response = memberService.getMyCommunity(memberResponse, kind, page);
+        MyPageCommunityResponse response = memberService.getMyCommunity(loginMember.getId(), kind, page);
         return ResponseEntity.ok(response);
     }
 
@@ -86,8 +95,7 @@ public class MemberController {
     public ResponseEntity<Page<MyPageContentResponse>> getMyContents(
             @Parameter(description = "accessToken 값", in = ParameterIn.HEADER) @AuthenticationPrincipal LoginMember loginMember,
             @Parameter(description = "현재 게시글 페이지 값", in = ParameterIn.PATH) @RequestParam(required = false, defaultValue = "0", value = "page") Integer page) {
-        MemberResponse memberResponse = memberService.findById(loginMember.getId());
-        Page<MyPageContentResponse> response = memberService.getMyContents(memberResponse, page);
+        Page<MyPageContentResponse> response = memberService.getMyContents(loginMember.getId(), page);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/greenUs/server/member/domain/Address.java
+++ b/src/main/java/com/greenUs/server/member/domain/Address.java
@@ -1,17 +1,16 @@
 package com.greenUs.server.member.domain;
 
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
 @Embeddable
-@NoArgsConstructor
-@AllArgsConstructor
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Address {
 
     @Column(name = "zipcode")
@@ -22,4 +21,11 @@ public class Address {
 
     @Column(name = "addressDetail")
     private String addressDetail; // 상세 정보 (ex. 501호)
+
+    @Builder
+    protected Address(String zipCode, String address, String addressDetail) {
+        this.zipCode = zipCode;
+        this.address = address;
+        this.addressDetail = addressDetail;
+    }
 }

--- a/src/main/java/com/greenUs/server/member/domain/Member.java
+++ b/src/main/java/com/greenUs/server/member/domain/Member.java
@@ -5,9 +5,9 @@ import com.greenUs.server.common.BaseEntity;
 
 import javax.persistence.*;
 
+import com.greenUs.server.coupon.domain.Coupon;
 import com.greenUs.server.product.domain.ProductLike;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
@@ -15,7 +15,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
 	@Id @GeneratedValue
@@ -38,12 +38,6 @@ public class Member extends BaseEntity {
 	@Column(name = "nickname")
 	private String nickname;
 
-	@OneToMany(mappedBy = "member",cascade = CascadeType.REMOVE)
-	private List<Basket> baskets = new ArrayList<>();
-
-	@OneToMany(mappedBy = "member",cascade = CascadeType.REMOVE)
-	private List<ProductLike> ProductLikes = new ArrayList<>();
-
 	@Embedded
 	private Address address;
 
@@ -61,21 +55,34 @@ public class Member extends BaseEntity {
 	@ColumnDefault("0")
 	private int point;
 
-	public Member() {}
-	public Member(String email, String name, SocialType socialType, String token ) {
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "member",cascade = CascadeType.REMOVE)
+	private List<Basket> baskets = new ArrayList<>();
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "member",cascade = CascadeType.REMOVE)
+	private List<ProductLike> ProductLikes = new ArrayList<>();
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "member", cascade = CascadeType.REMOVE)
+	private List<Coupon> coupons = new ArrayList<>();
+
+	@Builder
+	protected Member(String email, String nickName, SocialType socialType, String token) {
 		this.email = email;
-		this.name = name;
+		this.nickname = nickName;
 		this.socialType = socialType;
 		this.token = token;
 	}
 
-	public void change(String token) {
+	public void changeToken(String token) {
 		this.token = token;
 	}
 
 	public void changeInfo(String nickname, Address address, String phoneNum, String interestArea) {
 		this.nickname = nickname;
-		this.address = new Address(address.getZipCode(), address.getAddress(), address.getAddressDetail());
+		this.address = Address.builder()
+				.zipCode(address.getZipCode())
+				.address(address.getAddress())
+				.addressDetail(address.getAddressDetail())
+				.build();
 		this.phoneNum = phoneNum;
 		this.interestArea = interestArea;
 	}

--- a/src/main/java/com/greenUs/server/member/domain/Member.java
+++ b/src/main/java/com/greenUs/server/member/domain/Member.java
@@ -55,15 +55,6 @@ public class Member extends BaseEntity {
 	@ColumnDefault("0")
 	private int point;
 
-	@OneToMany(fetch = FetchType.LAZY, mappedBy = "member",cascade = CascadeType.REMOVE)
-	private List<Basket> baskets = new ArrayList<>();
-
-	@OneToMany(fetch = FetchType.LAZY, mappedBy = "member",cascade = CascadeType.REMOVE)
-	private List<ProductLike> ProductLikes = new ArrayList<>();
-
-	@OneToMany(fetch = FetchType.LAZY, mappedBy = "member", cascade = CascadeType.REMOVE)
-	private List<Coupon> coupons = new ArrayList<>();
-
 	@Builder
 	protected Member(String email, String nickName, SocialType socialType, String token) {
 		this.email = email;

--- a/src/main/java/com/greenUs/server/member/dto/response/MyPagePurchaseResponse.java
+++ b/src/main/java/com/greenUs/server/member/dto/response/MyPagePurchaseResponse.java
@@ -1,13 +1,17 @@
 package com.greenUs.server.member.dto.response;
 
-import com.greenUs.server.purchase.dto.response.PurchaseResponse;
-import lombok.AllArgsConstructor;
+import com.greenUs.server.product.domain.Brand;
+import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.domain.Page;
 
+// TODO: 아직 DTO 완성단계 아님
 @Getter
-@AllArgsConstructor
+@Builder
 public class MyPagePurchaseResponse {
-    private MyPageProfileResponse myPageProfileResponse;
-    private Page<PurchaseResponse> purchaseResponses;
+    private Long productId;
+    private Brand brand;
+    private String title;
+    private String thumbnail;
+    private int price;
+    private int count;
 }

--- a/src/main/java/com/greenUs/server/member/repository/MemberRepository.java
+++ b/src/main/java/com/greenUs/server/member/repository/MemberRepository.java
@@ -2,19 +2,10 @@ package com.greenUs.server.member.repository;
 
 import com.greenUs.server.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
     Member findByEmail(String email);
 
-    @Query("select m from Member m left join fetch m.baskets where m.id = :id")
-    Optional<Member> findByIdFetchBaskets(@Param("id") Long id);
-
-    @Query("select m from Member m left join fetch m.ProductLikes where m.id = :id")
-    Optional<Member> findByIdFetchLikes(@Param("id") Long id);
 }

--- a/src/main/java/com/greenUs/server/member/service/MemberService.java
+++ b/src/main/java/com/greenUs/server/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.greenUs.server.product.repository.ProductLikeRepository;
 import com.greenUs.server.product.repository.ProductRepository;
 import com.greenUs.server.purchase.domain.Purchase;
 import com.greenUs.server.purchase.domain.PurchaseProduct;
+import com.greenUs.server.purchase.repository.PurchaseProductRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -22,8 +23,6 @@ import com.greenUs.server.member.repository.MemberRepository;
 import com.greenUs.server.member.dto.response.MyPageCommentResponse;
 import com.greenUs.server.member.dto.response.MyPagePostResponse;
 import com.greenUs.server.post.repository.PostRepository;
-import com.greenUs.server.purchase.dto.response.PurchaseResponse;
-import com.greenUs.server.purchase.repository.PurchaseRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -38,54 +37,50 @@ public class MemberService {
 	private static final int PRODUCT_LIKE_COUNT = 8;
 
 	private final MemberRepository memberRepository;
-	private final PurchaseRepository purchaseRepository;
 	private final CouponRepository couponRepository;
 	private final PostRepository postRepository;
 	private final CommentRepository commentRepository;
 	private final BookmarkRepository bookmarkRepository;
-
 	private final ProductRepository productRepository;
+	private final PurchaseProductRepository purchaseProductRepository;
 	private final ProductLikeRepository productLikeRepository;
 
-	public MemberResponse findById(Long id) {
+	public MyPageProfileResponse getMyProfile(Long id) {
 		Member member = memberRepository.findById(id).orElseThrow(NotFoundMemberException::new);
-		return new MemberResponse(member);
+		return new MyPageProfileResponse(
+				member.getId(),
+				member.getName(),
+				member.getNickname(),
+				member.getLevel(),
+				0, // 찜은 추후 구현
+				member.getPoint(),
+				couponRepository.findCountByMemberId(member.getId())
+		);
 	}
 
-	public Page<PurchaseResponse> getMyOrder(MemberResponse member, int page) {
+	public List<MyPagePurchaseResponse> getMyPurchase(Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+		List<MyPagePurchaseResponse> responses = new ArrayList<>();
 
-		List<Purchase> purchases = purchaseRepository.findAllByMemberId(member.getId());
+		List<PurchaseProduct> purchaseProducts = purchaseProductRepository.findAllByMemberId(memberId);
 
-		List<PurchaseProduct> purchaseProducts = new ArrayList<>();
+		for (PurchaseProduct purchaseProduct : purchaseProducts) {
 
-		for (Purchase purchase : purchases) {
-			purchaseProducts.addAll(purchase.getPurchaseProducts());
+			MyPagePurchaseResponse product = MyPagePurchaseResponse.builder()
+					.productId(purchaseProduct.getProduct().getId())
+					.brand(purchaseProduct.getProduct().getBrand())
+					.title(purchaseProduct.getProduct().getTitle())
+					.thumbnail(purchaseProduct.getProduct().getThumbnail())
+					.price(purchaseProduct.getProduct().getPrice())
+					.count(purchaseProduct.getPurchaseCount())
+					.build();
+			responses.add(product);
 		}
-
-		return null;
-
-//		return purchases.map(purchase ->
-//				PurchaseResponse
-//						.builder()
-//						.id(purchase.getId())
-//						.delivery(purchase.getDelivery())
-//						.totalPrice(purchase.getTotalPrice())
-//						.build());
-
-//		MyPageProfileResponse myPageProfileResponse = new MyPageProfileResponse(
-//				member.getId(),
-//				member.getName(),
-//				member.getNickname(),
-//				member.getLevel(),
-//				0, // 찜은 추후 구현
-//				member.getPoint(),
-//				couponRepository.findCountByMemberId(member.getId())
-//		);
-
-		//return new MyPagePurchaseResponse(myPageProfileResponse, purchaseResponses);
+		return responses;
 	}
 
-	public MyPageCommunityResponse getMyCommunity(MemberResponse member, String kind, int page) {
+	public MyPageCommunityResponse getMyCommunity(Long memberId, String kind, int page) {
+		Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
 		PageRequest pageRequest = PageRequest.of(page, 8);
 
 		MyPageCommunityResponse myPageCommunityResponse = new MyPageCommunityResponse(
@@ -112,7 +107,8 @@ public class MemberService {
 		return null;
 	}
 
-	public Page<MyPageContentResponse> getMyContents(MemberResponse member, int page) {
+	public Page<MyPageContentResponse> getMyContents(Long memberId, int page) {
+		Member member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
 		PageRequest pageRequest = PageRequest.of(page, 10);
 		Page<Bookmark> bookmarks = bookmarkRepository.findByMemberId(member.getId(), pageRequest);
 

--- a/src/main/java/com/greenUs/server/member/service/MemberService.java
+++ b/src/main/java/com/greenUs/server/member/service/MemberService.java
@@ -3,6 +3,8 @@ package com.greenUs.server.member.service;
 import com.greenUs.server.member.dto.response.*;
 import com.greenUs.server.product.repository.ProductLikeRepository;
 import com.greenUs.server.product.repository.ProductRepository;
+import com.greenUs.server.purchase.domain.Purchase;
+import com.greenUs.server.purchase.domain.PurchaseProduct;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -50,22 +52,37 @@ public class MemberService {
 		return new MemberResponse(member);
 	}
 
-	public MyPagePurchaseResponse getMyOrder(MemberResponse member, int page) {
+	public Page<PurchaseResponse> getMyOrder(MemberResponse member, int page) {
 
-		PageRequest pageRequest = PageRequest.of(page, 10);
-		Page<PurchaseResponse> purchaseResponses = purchaseRepository.findByMemberId(member.getId(), pageRequest);
-		return new MyPagePurchaseResponse(
-			new MyPageProfileResponse(
-					member.getId(),
-					member.getName(),
-					member.getNickname(),
-					member.getLevel(),
-					0, // 찜은 추후 구현
-					member.getPoint(),
-					couponRepository.findCountByMemberId(member.getId())
-			),
-			purchaseResponses
-		);
+		List<Purchase> purchases = purchaseRepository.findAllByMemberId(member.getId());
+
+		List<PurchaseProduct> purchaseProducts = new ArrayList<>();
+
+		for (Purchase purchase : purchases) {
+			purchaseProducts.addAll(purchase.getPurchaseProducts());
+		}
+
+		return null;
+
+//		return purchases.map(purchase ->
+//				PurchaseResponse
+//						.builder()
+//						.id(purchase.getId())
+//						.delivery(purchase.getDelivery())
+//						.totalPrice(purchase.getTotalPrice())
+//						.build());
+
+//		MyPageProfileResponse myPageProfileResponse = new MyPageProfileResponse(
+//				member.getId(),
+//				member.getName(),
+//				member.getNickname(),
+//				member.getLevel(),
+//				0, // 찜은 추후 구현
+//				member.getPoint(),
+//				couponRepository.findCountByMemberId(member.getId())
+//		);
+
+		//return new MyPagePurchaseResponse(myPageProfileResponse, purchaseResponses);
 	}
 
 	public MyPageCommunityResponse getMyCommunity(MemberResponse member, String kind, int page) {

--- a/src/main/java/com/greenUs/server/post/domain/Post.java
+++ b/src/main/java/com/greenUs/server/post/domain/Post.java
@@ -14,6 +14,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.PrePersist;
 
+import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
 
 import com.greenUs.server.attachment.domain.Attachment;
@@ -22,16 +23,10 @@ import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.hashtag.domain.Hashtag;
 import com.greenUs.server.member.domain.Member;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-
-@ToString
-@NoArgsConstructor
-@Getter
 @DynamicUpdate
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
 
 	@Id
@@ -70,7 +65,7 @@ public class Post extends BaseEntity {
 	private List<Attachment> attachments = new ArrayList<>();
 
 	@Builder
-	public Post(Member member, Integer kind, String title, String content, Integer price, Boolean fileAttached) {
+	protected Post(Member member, Integer kind, String title, String content, Integer price, Boolean fileAttached) {
 		this.member = member;
 		this.kind = kind;
 		this.title = title;

--- a/src/main/java/com/greenUs/server/post/domain/Recommend.java
+++ b/src/main/java/com/greenUs/server/post/domain/Recommend.java
@@ -12,12 +12,13 @@ import javax.persistence.ManyToOne;
 import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.member.domain.Member;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@Getter
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recommend extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/greenUs/server/product/domain/Product.java
+++ b/src/main/java/com/greenUs/server/product/domain/Product.java
@@ -1,16 +1,11 @@
 package com.greenUs.server.product.domain;
 
-import com.greenUs.server.attachment.domain.Attachment;
 import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.product.converter.BadgeConverter;
 import com.greenUs.server.product.converter.CategoryConverter;
-import com.greenUs.server.purchase.domain.PurchaseProduct;
 import com.greenUs.server.reviewAndAsk.domain.Ask;
 import com.greenUs.server.reviewAndAsk.domain.Review;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -18,9 +13,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends BaseEntity {
 
     @Id @GeneratedValue
@@ -56,9 +49,6 @@ public class Product extends BaseEntity {
     private Integer askCount;
 
     private String thumbnail;
-
-    @OneToMany(mappedBy = "product",cascade = CascadeType.ALL)
-    private List<PurchaseProduct> purchaseProducts =new ArrayList<>();
 
     @OneToMany(mappedBy = "product",cascade = CascadeType.ALL)
     private List<Review> reviews = new ArrayList<>();

--- a/src/main/java/com/greenUs/server/product/domain/ProductLike.java
+++ b/src/main/java/com/greenUs/server/product/domain/ProductLike.java
@@ -2,18 +2,13 @@ package com.greenUs.server.product.domain;
 
 
 import com.greenUs.server.member.domain.Member;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductLike {
 
     @Id
@@ -27,4 +22,10 @@ public class ProductLike {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
+
+    @Builder
+    protected ProductLike(Member member, Product product) {
+        this.member = member;
+        this.product = product;
+    }
 }

--- a/src/main/java/com/greenUs/server/purchase/domain/Purchase.java
+++ b/src/main/java/com/greenUs/server/purchase/domain/Purchase.java
@@ -25,7 +25,6 @@ public class Purchase extends BaseEntity {
     private Member member;
 
     @OneToOne(fetch = FetchType.LAZY)
-    //@JoinColumn(name = "delivery_id")
     private Delivery delivery;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "purchase")

--- a/src/main/java/com/greenUs/server/purchase/domain/Purchase.java
+++ b/src/main/java/com/greenUs/server/purchase/domain/Purchase.java
@@ -3,18 +3,17 @@ package com.greenUs.server.purchase.domain;
 import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.delivery.domain.Delivery;
 import com.greenUs.server.member.domain.Member;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@NoArgsConstructor
-@ToString
-@Getter
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Purchase extends BaseEntity {
 
     @Id @GeneratedValue
@@ -25,11 +24,11 @@ public class Purchase extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne()
-    @JoinColumn(name = "delivery_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    //@JoinColumn(name = "delivery_id")
     private Delivery delivery;
 
-    @OneToMany(mappedBy = "purchase",cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "purchase")
     private List<PurchaseProduct> purchaseProducts = new ArrayList<>();
 
     private int totalPrice;

--- a/src/main/java/com/greenUs/server/purchase/domain/PurchaseProduct.java
+++ b/src/main/java/com/greenUs/server/purchase/domain/PurchaseProduct.java
@@ -26,6 +26,7 @@ public class PurchaseProduct extends BaseEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
+    private Long memberId;
     private int price=0;
     private int purchaseCount=0;
 }

--- a/src/main/java/com/greenUs/server/purchase/domain/PurchaseProduct.java
+++ b/src/main/java/com/greenUs/server/purchase/domain/PurchaseProduct.java
@@ -2,12 +2,15 @@ package com.greenUs.server.purchase.domain;
 
 import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.product.domain.Product;
-import lombok.ToString;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-@ToString
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PurchaseProduct extends BaseEntity {
 
     @Id
@@ -23,6 +26,6 @@ public class PurchaseProduct extends BaseEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
-    private int price;
-    private int purchaseCount;
+    private int price=0;
+    private int purchaseCount=0;
 }

--- a/src/main/java/com/greenUs/server/purchase/dto/response/PurchaseResponse.java
+++ b/src/main/java/com/greenUs/server/purchase/dto/response/PurchaseResponse.java
@@ -1,10 +1,13 @@
 package com.greenUs.server.purchase.dto.response;
 
 import com.greenUs.server.delivery.domain.Delivery;
-import com.greenUs.server.member.domain.Member;
 import com.greenUs.server.purchase.domain.Purchase;
 import com.greenUs.server.purchase.domain.PurchaseProduct;
+import lombok.Builder;
 import lombok.Getter;
+
+import com.greenUs.server.member.domain.Member;
+
 
 import java.util.List;
 
@@ -17,11 +20,12 @@ public class PurchaseResponse {
     private List<PurchaseProduct> purchaseProducts;
     private int totalPrice;
 
-    public PurchaseResponse(Purchase purchase) {
-        this.id = purchase.getId();
-        this.member = purchase.getMember();
-        this.delivery = purchase.getDelivery();
-        this.purchaseProducts = purchase.getPurchaseProducts();
-        this.totalPrice = purchase.getTotalPrice();
+    @Builder
+    public PurchaseResponse(Long id, Member member, Delivery delivery, List<PurchaseProduct> purchaseProducts, int totalPrice) {
+        this.id = id;
+        this.member = member;
+        this.delivery = delivery;
+        this.purchaseProducts = purchaseProducts;
+        this.totalPrice = totalPrice;
     }
 }

--- a/src/main/java/com/greenUs/server/purchase/repository/PurchaseProductRepository.java
+++ b/src/main/java/com/greenUs/server/purchase/repository/PurchaseProductRepository.java
@@ -1,10 +1,15 @@
 package com.greenUs.server.purchase.repository;
 
 
+import com.greenUs.server.member.domain.Member;
 import com.greenUs.server.purchase.domain.PurchaseProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PurchaseProductRepository extends JpaRepository<PurchaseProduct,Long> {
+
+    List<PurchaseProduct> findAllByMemberId(Long id);
 }

--- a/src/main/java/com/greenUs/server/purchase/repository/PurchaseRepository.java
+++ b/src/main/java/com/greenUs/server/purchase/repository/PurchaseRepository.java
@@ -1,19 +1,15 @@
 package com.greenUs.server.purchase.repository;
 
+import com.greenUs.server.member.domain.Member;
 import com.greenUs.server.purchase.domain.Purchase;
-import com.greenUs.server.purchase.dto.response.PurchaseResponse;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 
 
 @Repository
 public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
 
-    @Query("select p from Purchase p\n"
-        + "where p.member.id = :id")
-    Page<PurchaseResponse> findByMemberId(Long id, Pageable pageable);
+    List<Purchase> findAllByMember(Member member);
 }

--- a/src/main/java/com/greenUs/server/purchase/service/PurchaseService.java
+++ b/src/main/java/com/greenUs/server/purchase/service/PurchaseService.java
@@ -31,20 +31,25 @@ public class PurchaseService {
 
         ShippingAddress address = purchaseRequest.getAddress();
         // delivery 부터 저장
-        Delivery delivery = new Delivery(
-                address.getAddressName(),
-                address.getRecipient(),
-                address.getRecipientPhone(),
-                address.getZipCode(),
-                address.getAddress(),
-                address.getAddressDetail(),
-                "2023-02-20" // 임의로 해둔 배송 출발일
-        );
+        Delivery delivery = Delivery.builder()
+                        .addressName(address.getAddressName())
+                        .recipient(address.getRecipient())
+                        .recipientPhone(address.getRecipientPhone())
+                        .zipCode(address.getZipCode())
+                        .address(address.getAddress())
+                        .addressDetail(address.getAddressDetail())
+                        .deliverDate("2023-02-20") // 임의로 해둔 배송 출발일
+                        .build();
 
         deliveryRepository.save(delivery);
 
         Purchase purchase = purchaseRepository.save(new Purchase(member, delivery));
-        return new PurchaseResponse(purchase);
+        return PurchaseResponse.builder()
+                .id(purchase.getId())
+                .delivery(purchase.getDelivery())
+                .purchaseProducts(purchase.getPurchaseProducts())
+                .totalPrice(purchase.getTotalPrice())
+                .build();
     }
 
     public Page<PurchaseResponse> getList() {

--- a/src/main/java/com/greenUs/server/reviewAndAsk/domain/Ask.java
+++ b/src/main/java/com/greenUs/server/reviewAndAsk/domain/Ask.java
@@ -3,18 +3,13 @@ package com.greenUs.server.reviewAndAsk.domain;
 import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.member.domain.Member;
 import com.greenUs.server.product.domain.Product;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Ask extends BaseEntity {
 
     @Id @GeneratedValue
@@ -25,6 +20,10 @@ public class Ask extends BaseEntity {
 
     private String title;
 
+    private String answer;
+
+    private Boolean secret;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="product_id")
     private Product product;
@@ -32,9 +31,4 @@ public class Ask extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
-    private String answer;
-
-    private Boolean secret;
-
 }

--- a/src/main/java/com/greenUs/server/reviewAndAsk/domain/Review.java
+++ b/src/main/java/com/greenUs/server/reviewAndAsk/domain/Review.java
@@ -3,18 +3,13 @@ package com.greenUs.server.reviewAndAsk.domain;
 import com.greenUs.server.common.BaseEntity;
 import com.greenUs.server.member.domain.Member;
 import com.greenUs.server.product.domain.Product;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {
 
     @Id @GeneratedValue


### PR DESCRIPTION
## 구현기능
- 엔티티에 적용할 어노테이션 순서 통일
- 불필요한 어노테이션 제거
- 불필요 필드값 1차 제거 (purchase 부분은 아직 미완성)
- cascade 옵션 점검
- Builder 패턴 적용

- MemberController 에서 프로필 정보 얻는 api 추가

## 세부 구현기능
- 기본적으로는 아래와 같은 어노테이션 순서를 적용
추가로 protected 를 통해 접근성 제한
```java
@Entity
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
```

- `@ToString`은 개발과정에서만 필요하다 생각되어 제거
- Builder 패턴 클래스에 적용되어 있는 엔티티는 모두 메소드 레벨로 변경
- 굳이 연관된 그래프를 알 필요가 없는 엔티티에서는 연관된 필드값을 제거했습니다.

- 기존에는 마이페이지 관련 반환값에 모두 프로필 정보가 들어갔는데, 프로필 정보를 얻는 api 를 따로 구현
## 관련이슈
#92 
## 기타
1차적인 리펙토링이고 purchase 부분 구현하면서 추가적인 리펙토링이 진행될 예정입니다.