### PR TITLE
Refactor: 오늘의 인기글 추가 데이터 반환

### DIFF
--- a/src/main/java/com/greenUs/server/post/controller/PostController.java
+++ b/src/main/java/com/greenUs/server/post/controller/PostController.java
@@ -163,13 +163,13 @@ public class PostController {
 
 	@Operation(summary = "오늘의 그리너스 인기글", description = "오늘의 인기 게시글 목록을 조회 합니다.")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "오늘의 인기 게시글 조회 성공", content = @Content(schema = @Schema(implementation = PostDetailResponse.class))),
+		@ApiResponse(responseCode = "200", description = "오늘의 인기 게시글 조회 성공", content = @Content(schema = @Schema(implementation = PostListsResponse.class))),
 		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근", content = @Content(schema = @Schema(implementation = Error.class)))
 	})
 	@GetMapping("/popularity")
-	public ResponseEntity<List<PostPopularityResponse>> getPopularPosts() {
+	public ResponseEntity<List<PostListsResponse>> getPopularPosts() {
 
-		List<PostPopularityResponse> postResponseDto = postService.getPopularPosts();
+		List<PostListsResponse> postResponseDto = postService.getPopularPosts();
 
 		return new ResponseEntity<>(postResponseDto, HttpStatus.OK);
 	}

--- a/src/main/java/com/greenUs/server/post/service/PostService.java
+++ b/src/main/java/com/greenUs/server/post/service/PostService.java
@@ -37,6 +37,7 @@ public class PostService {
 
 	private static final int PAGE_POST_COUNT = 6;
 	private static final int PAGE_SEARCH_POST_COUNT = 10;
+	private static final int POST_RENEW_PERIOD = 365;
 	private final PostRepository postRepository;
 	private final RecommendRepository recommendRepository;
 	private final HashtagService hashtagService;
@@ -168,7 +169,7 @@ public class PostService {
 
 	public List<PostListsResponse> getPopularPosts() {
 
-		LocalDateTime startDatetime = LocalDateTime.of(LocalDate.now().minusDays(365), LocalTime.of(0, 0, 0));
+		LocalDateTime startDatetime = LocalDateTime.of(LocalDate.now().minusDays(POST_RENEW_PERIOD), LocalTime.of(0, 0, 0));
 		LocalDateTime endDatetime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 59, 59));
 		List<Post> posts = postRepository.findTop3ByCreatedAtBetweenOrderByRecommendCntDesc(startDatetime, endDatetime);
 

--- a/src/main/java/com/greenUs/server/post/service/PostService.java
+++ b/src/main/java/com/greenUs/server/post/service/PostService.java
@@ -166,16 +166,16 @@ public class PostService {
 		recommendRepository.delete(recommend);
 	}
 
-	public List<PostPopularityResponse> getPopularPosts() {
+	public List<PostListsResponse> getPopularPosts() {
 
-		LocalDateTime startDatetime = LocalDateTime.of(LocalDate.now().minusDays(1), LocalTime.of(0, 0, 0));
+		LocalDateTime startDatetime = LocalDateTime.of(LocalDate.now().minusDays(365), LocalTime.of(0, 0, 0));
 		LocalDateTime endDatetime = LocalDateTime.of(LocalDate.now(), LocalTime.of(23, 59, 59));
 		List<Post> posts = postRepository.findTop3ByCreatedAtBetweenOrderByRecommendCntDesc(startDatetime, endDatetime);
 
-		List<PostPopularityResponse> postResponseDto = new ArrayList<>();
+		List<PostListsResponse> postResponseDto = new ArrayList<>();
 
 		for (Post post : posts) {
-			postResponseDto.add(new PostPopularityResponse(post));
+			postResponseDto.add(new PostListsResponse(post));
 		}
 
 		return postResponseDto;


### PR DESCRIPTION
## 구현기능

오늘의 인기글 데이터 추가 반환

## 세부 구현기능

1. 인기글 기간 수정 (1일 -> 365일)
2. 오늘의 인기글 추가 데이터 반환

## 관련이슈

#94 

## 기타

인기글 기간 수정은 상용 서비스가 아니다 보니 하루면 인기글 데이터가 사라지는 문제가 생겨 1일 -> 365일로 프론트 측과 상의 후 변경 하였습니다.