### PR TITLE
Feature: refresh token redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### env ###
+.env*

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'mysql:mysql-connector-java'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// configuration
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 

--- a/src/main/java/com/greenUs/server/auth/application/AuthService.java
+++ b/src/main/java/com/greenUs/server/auth/application/AuthService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -25,6 +26,7 @@ public class AuthService {
         Member foundMember = findMember(oAuthMember);
         foundMember.changeToken(oAuthMember.getRefreshToken());
         AuthToken authToken = tokenCreator.createAuthToken(foundMember.getId());
+
         return new AccessRefreshTokenResponse(authToken.getAccessToken(), authToken.getRefreshToken(), foundMember.getNickname() == null);
     }
 
@@ -37,8 +39,8 @@ public class AuthService {
 
     public AccessTokenResponse generateAccessToken(TokenRenewalRequest tokenRenewalRequest) {
         String refreshToken = tokenRenewalRequest.getRefreshToken();
-        AuthToken authToken = tokenCreator.renewAuthToken(refreshToken);
-        return new AccessTokenResponse(authToken.getAccessToken());
+        String accessToken = tokenCreator.renewAccessToken(refreshToken);
+        return new AccessTokenResponse(accessToken);
     }
 
     public Long extractMemberId(String accessToken) {

--- a/src/main/java/com/greenUs/server/auth/application/AuthService.java
+++ b/src/main/java/com/greenUs/server/auth/application/AuthService.java
@@ -24,7 +24,6 @@ public class AuthService {
     @Transactional
     public AccessRefreshTokenResponse generateAccessAndRefreshToken(OAuthMember oAuthMember) {
         Member foundMember = findMember(oAuthMember);
-        foundMember.changeToken(oAuthMember.getRefreshToken());
         AuthToken authToken = tokenCreator.createAuthToken(foundMember.getId());
 
         return new AccessRefreshTokenResponse(authToken.getAccessToken(), authToken.getRefreshToken(), foundMember.getNickname() == null);

--- a/src/main/java/com/greenUs/server/auth/application/TokenCreator.java
+++ b/src/main/java/com/greenUs/server/auth/application/TokenCreator.java
@@ -5,7 +5,7 @@ import com.greenUs.server.auth.domain.AuthToken;
 public interface TokenCreator {
 
     AuthToken createAuthToken(Long memberId);
-    AuthToken renewAuthToken(String refreshToken);
-
+    String renewAccessToken(String refreshToken);
     Long extractPayload(String accessToken);
+    void deleteRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/greenUs/server/auth/controller/AuthController.java
+++ b/src/main/java/com/greenUs/server/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.greenUs.server.auth.controller;
 import com.greenUs.server.auth.application.AuthService;
 import com.greenUs.server.auth.application.OAuthClient;
 import com.greenUs.server.auth.application.OAuthUri;
+import com.greenUs.server.auth.application.TokenCreator;
 import com.greenUs.server.auth.dto.LoginMember;
 import com.greenUs.server.auth.dto.OAuthMember;
 import com.greenUs.server.auth.dto.request.TokenRenewalRequest;
@@ -10,7 +11,6 @@ import com.greenUs.server.auth.dto.request.TokenRequest;
 import com.greenUs.server.auth.dto.response.AccessRefreshTokenResponse;
 import com.greenUs.server.auth.dto.response.AccessTokenResponse;
 import com.greenUs.server.auth.dto.response.OAuthUriResponse;
-import com.greenUs.server.auth.exception.RefreshTokenNotExistException;
 import com.greenUs.server.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -39,6 +39,7 @@ public class AuthController {
     private final OAuthUri oAuthUri;
     private final OAuthClient oAuthClient;
     private final AuthService authService;
+    private final TokenCreator tokenCreator;
     private final CookieProvider cookieProvider;
 
     @Operation(summary = "로그인 화면으로 가기 위한 url 반환", description = "로그인 화면으로 가기 위한 url 반환 로그인에 성공하면 지정된 redirect uri 로 인가 코드 발급")
@@ -99,8 +100,7 @@ public class AuthController {
     public ResponseEntity<Void> logout(
             @CookieValue(value = REFRESH_TOKEN, required = false) final String refreshToken
     ) {
-        if (refreshToken == null)
-            throw new RefreshTokenNotExistException();
+        tokenCreator.deleteRefreshToken(refreshToken);
         ResponseCookie cookie = cookieProvider.deleteCookie(refreshToken);
         return ResponseEntity.noContent()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/src/main/java/com/greenUs/server/auth/controller/CookieProvider.java
+++ b/src/main/java/com/greenUs/server/auth/controller/CookieProvider.java
@@ -1,0 +1,40 @@
+package com.greenUs.server.auth.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class CookieProvider {
+
+    protected static final String REFRESH_TOKEN = "refreshToken";
+    private static final int REMOVE_AGE = 0;
+    private final long refreshTokenValidity;
+
+    public CookieProvider(@Value("${security.jwt.token.refresh.expire-length}") long refreshTokenValidity) {
+        this.refreshTokenValidity = refreshTokenValidity;
+    }
+
+    public ResponseCookie createCookie(String refreshToken) {
+        return ResponseCookie.from(REFRESH_TOKEN, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite(Cookie.SameSite.NONE.attributeValue())
+                .maxAge(Duration.ofMillis(refreshTokenValidity))
+                .build();
+    }
+
+    public ResponseCookie deleteCookie(String refreshToken) {
+        return ResponseCookie.from(REFRESH_TOKEN, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite(Cookie.SameSite.NONE.attributeValue())
+                .maxAge(Duration.ofMillis(REMOVE_AGE))
+                .build();
+    }
+}

--- a/src/main/java/com/greenUs/server/auth/domain/RefreshToken.java
+++ b/src/main/java/com/greenUs/server/auth/domain/RefreshToken.java
@@ -1,0 +1,52 @@
+package com.greenUs.server.auth.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+    @Id
+    private String refreshToken;
+
+    private Long memberId;
+
+    @TimeToLive
+    private long expiration;
+
+    @Builder
+    public RefreshToken(String refreshToken, Long memberId, long expiration) {
+        this.refreshToken = checkRefreshToken(refreshToken);
+        this.memberId = checkUserId(memberId);
+        this.expiration = checkExpiration(expiration);
+    }
+
+    private String checkRefreshToken(String refreshToken) {
+        if (refreshToken.isBlank())
+            throw new IllegalArgumentException("refresh 토큰 비어있음");
+
+        return refreshToken;
+    }
+
+    private Long checkUserId(Long userId) {
+        if (userId < 1)
+            throw new IllegalArgumentException("올바르지 않은 유저 아이디");
+
+        return userId;
+    }
+
+    private long checkExpiration(long expiration) {
+        if (expiration < 1)
+            throw new IllegalArgumentException("올바르지 않은 만료 시간");
+
+        return expiration;
+    }
+}

--- a/src/main/java/com/greenUs/server/auth/dto/OAuthMember.java
+++ b/src/main/java/com/greenUs/server/auth/dto/OAuthMember.java
@@ -18,9 +18,8 @@ public class OAuthMember {
     public Member toMember() {
         return Member.builder()
                 .email(email)
-                .nickName(displayName)
+                .name(displayName)
                 .socialType(SocialType.GOOGLE)
-                .token(refreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/greenUs/server/auth/exception/RefreshTokenNotExistException.java
+++ b/src/main/java/com/greenUs/server/auth/exception/RefreshTokenNotExistException.java
@@ -1,0 +1,11 @@
+package com.greenUs.server.auth.exception;
+
+public class RefreshTokenNotExistException extends RuntimeException{
+
+    public RefreshTokenNotExistException(String message) {
+        super(message);
+    }
+    public RefreshTokenNotExistException() {
+        this("refresh token 이 없습니다.");
+    }
+}

--- a/src/main/java/com/greenUs/server/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/greenUs/server/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.greenUs.server.auth.repository;
+
+import com.greenUs.server.auth.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+}

--- a/src/main/java/com/greenUs/server/global/config/RedisConfig.java
+++ b/src/main/java/com/greenUs/server/global/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.greenUs.server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+        stringRedisTemplate.setDefaultSerializer(new StringRedisSerializer()); // redis-cli을 통해 데이터 확인시에 편리하게 하기 위함
+        return stringRedisTemplate;
+    }
+}

--- a/src/main/java/com/greenUs/server/global/error/ErrorCode.java
+++ b/src/main/java/com/greenUs/server/global/error/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(400, "엔티티를 찾을 수 없습니다."),
     INVALID_TOKEN(401, "잘못된 토큰입니다."),
     EXPIRED_TOKEN(401, "만료된 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(401, "리프레시 토큰이 없습니다."),
     POST_MEMBER_NOT_EQUAL(403, "게시글의 작성자가 아닙니다."),
     POST_COMMENT_NOT_EQUAL(403,"해당하는 게시글의 댓글 번호가 아닙니다."),
     POST_ATTACHMENT_NOT_EQUAL(403, "게시글의 첨부파일 이름이 아닙니다."),

--- a/src/main/java/com/greenUs/server/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/greenUs/server/global/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.greenUs.server.attachment.exception.NotEqualAttachmentAndPostAttachme
 import com.greenUs.server.attachment.exception.NotFoundObjectException;
 import com.greenUs.server.auth.exception.EmptyAuthorizationHeaderException;
 import com.greenUs.server.auth.exception.InvalidTokenException;
+import com.greenUs.server.auth.exception.RefreshTokenNotExistException;
 import com.greenUs.server.comment.exception.NotEqualCommentAndPostComment;
 import com.greenUs.server.comment.exception.NotEqualMemberAndCommentMember;
 import com.greenUs.server.comment.exception.NotFoundCommentException;
@@ -26,7 +27,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(InvalidTokenException.class)
+    @ExceptionHandler({InvalidTokenException.class, RefreshTokenNotExistException.class})
     public ResponseEntity<ErrorResponse> handleInvalidAuthorization(RuntimeException e) {
         ErrorResponse response = new ErrorResponse(ErrorCode.INVALID_TOKEN);
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);

--- a/src/main/java/com/greenUs/server/member/domain/Member.java
+++ b/src/main/java/com/greenUs/server/member/domain/Member.java
@@ -1,17 +1,11 @@
 package com.greenUs.server.member.domain;
 
-import com.greenUs.server.basket.domain.Basket;
 import com.greenUs.server.common.BaseEntity;
 
 import javax.persistence.*;
 
-import com.greenUs.server.coupon.domain.Coupon;
-import com.greenUs.server.product.domain.ProductLike;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -25,9 +19,6 @@ public class Member extends BaseEntity {
 	@Enumerated(value = EnumType.STRING)
 	@Column(name = "social_type", nullable = false)
 	private SocialType socialType;
-
-	@Column(name = "token", nullable = false)
-	private String token;
 
 	@Column(name = "email", nullable = false)
 	private String email;
@@ -56,15 +47,10 @@ public class Member extends BaseEntity {
 	private int point;
 
 	@Builder
-	protected Member(String email, String nickName, SocialType socialType, String token) {
+	protected Member(String email, String name, SocialType socialType) {
 		this.email = email;
-		this.nickname = nickName;
+		this.name = name;
 		this.socialType = socialType;
-		this.token = token;
-	}
-
-	public void changeToken(String token) {
-		this.token = token;
 	}
 
 	public void changeInfo(String nickname, Address address, String phoneNum, String interestArea) {

--- a/src/main/java/com/greenUs/server/member/domain/Member.java
+++ b/src/main/java/com/greenUs/server/member/domain/Member.java
@@ -32,7 +32,7 @@ public class Member extends BaseEntity {
 	@Column(name = "email", nullable = false)
 	private String email;
 
-	@Column(name = "name", nullable = false)
+	@Column(name = "name")
 	private String name;
 
 	@Column(name = "nickname")

--- a/src/main/resources/application-bucket.yml
+++ b/src/main/resources/application-bucket.yml
@@ -1,0 +1,14 @@
+cloud:
+  aws:
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY}
+      secretKey: ${AWS_SECRET_KEY}
+    s3:
+      bucket: greenus
+      dir: /greenus
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    cloudfront:
+      domain: ${AWS_CLOUDFRONT_DOMAIN}

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -15,3 +15,7 @@ spring:
         jdbc:
           time_zone: Asia/Seoul
     show-sql: true
+
+  redis:
+    host: localhost
+    port: 6379

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/greenus?useUnicode=true&serverTimezone=Asia/Seoul
-    username: root
-    password: password
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
   jpa:
     hibernate:
@@ -17,5 +17,5 @@ spring:
     show-sql: true
 
   redis:
-    host: localhost
-    port: 6379
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,23 +5,11 @@ springdoc:
     groups:
       enabled: true
   swagger-ui:
-    operations-sorter: alpha # alpha(??? ????), method(HTTP????)
-    tags-sorter: alpha # ?? ?? ??
-    path: /swagger-ui.html # html ?? ?? ??
+    operations-sorter: alpha
+    tags-sorter: alpha
+    path: /swagger-ui.html
     disable-swagger-default-url: true
     display-query-params-without-oauth2: true
-    doc-expansion: none # tag, operation ??? ??
+    doc-expansion: none
   paths-to-match:
     - /**
-
-oauth:
-  google:
-    client-id: client-id
-    client-secret: client-secret
-    oauth-end-point: https://accounts.google.com/o/oauth2/v2/auth
-    response-type: code
-    scopes:
-      - https://www.googleapis.com/auth/userinfo.profile
-      - https://www.googleapis.com/auth/userinfo.email
-    token-uri: https://oauth2.googleapis.com/token
-    access-type: offline

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,8 +1,20 @@
 security:
   jwt:
     token:
-      secret-key: zero-waste-secret-key-made-by-sangwoo
+      secret-key: ${JWT_SECRET_KEY}
       access:
         expire-length: 1800000 # 30min
       refresh:
         expire-length: 2592000000 # 30 days
+
+oauth:
+  google:
+    client-id: ${CLIENT_ID}
+    client-secret: ${CLIENT_SECRET}
+    oauth-end-point: https://accounts.google.com/o/oauth2/v2/auth
+    response-type: code
+    scopes:
+      - https://www.googleapis.com/auth/userinfo.profile
+      - https://www.googleapis.com/auth/userinfo.email
+    token-uri: https://oauth2.googleapis.com/token
+    access-type: offline

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
+  config:
+    import: .env.yml
   profiles:
     include: db,dev,local,security,bucket
+
+


### PR DESCRIPTION
## 구현기능
1. 쿠키에 refreshToken 넣어주기
2. refreshToken 담을 redis 적용
3. member 테이블에 refreshToken 제거
4. resoures yml 파일 값 환경변수로 지정

## 세부 구현기능
1. 로그인, 로그아웃 진행시 쿠키에 refreshToken 넣어주기 (기존에는 응답 값으로 넘겨주었음)
2. 보안상의 이유로 refreshToken 을 급하게 처리해야 할 경우가 있을 수 있음, 토큰은 발급 이후 따로 관리가 불가능하기에 redis 를 통해 관리
3. 기존에 member 테이블의 필드값으로 넣어뒀던 refreshToken 을 제거
4. 환경변수 지정

## 관련이슈
#10 
## 기타
AWS 서버에 Redis DB 설치가 되어야 합니다.